### PR TITLE
Burger v1 and v2 Router change to Unisave

### DIFF
--- a/bscpd/strategy/bnb.sol
+++ b/bscpd/strategy/bnb.sol
@@ -186,7 +186,7 @@ contract StrategyFortube {
     address constant public eth_address = address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB);
     address constant public want = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); //wbnb
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0xBf6527834dBB89cdC97A79FCD62E6c08B19F8ec0);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); //Unisave
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);

--- a/bscpd/strategy/busd.sol
+++ b/bscpd/strategy/busd.sol
@@ -181,7 +181,7 @@ contract StrategyFortube {
     using SafeMath for uint256;
     
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0x9FdC672a33f34675253041671abd214F2387b7aB);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); // Unisave
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);
@@ -205,7 +205,7 @@ contract StrategyFortube {
     address public governance;
     address public strategyDev;
     address public controller;
-    address public burnAddress = 0xB6af2DabCEBC7d30E440714A33E5BD45CEEd103a;
+    address public burnAddress = 0xB6af2DabCEBC7d30E440714A33E5BD45CEEd103a; // ?
 
     string public getName;
 

--- a/bscpd/strategy/eth.sol
+++ b/bscpd/strategy/eth.sol
@@ -4,7 +4,7 @@ contract StrategyFortube {
     using SafeMath for uint256;
     
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0xBf6527834dBB89cdC97A79FCD62E6c08B19F8ec0);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); // unisave 
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);

--- a/bscpd/strategy/usdt.sol
+++ b/bscpd/strategy/usdt.sol
@@ -181,7 +181,7 @@ contract StrategyFortube {
     using SafeMath for uint256;
     
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0x9FdC672a33f34675253041671abd214F2387b7aB);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); // Unisave
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);

--- a/contracts/standard/v2/bsc/fordeploy.sol
+++ b/contracts/standard/v2/bsc/fordeploy.sol
@@ -158,7 +158,7 @@ contract StrategyFortube {
     using SafeMath for uint256;
     
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0xBf6527834dBB89cdC97A79FCD62E6c08B19F8ec0);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); // Unisave
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);

--- a/contracts/standard/v2/bsc/strategyFor.sol
+++ b/contracts/standard/v2/bsc/strategyFor.sol
@@ -181,7 +181,7 @@ contract StrategyFortube {
     using SafeMath for uint256;
     
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0xBf6527834dBB89cdC97A79FCD62E6c08B19F8ec0);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); // Unisave
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);

--- a/contracts/standard/v2/bsc/strategyForBNB.sol
+++ b/contracts/standard/v2/bsc/strategyForBNB.sol
@@ -182,7 +182,7 @@ contract StrategyFortube {
     address constant public eth_address = address(0xbBbBBBBbbBBBbbbBbbBbbbbBBbBbbbbBbBbbBBbB);
     address constant public want = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); //wbnb
     address constant public output = address(0x658A109C5900BC6d2357c87549B651670E5b0539); //for
-    address  public unirouter = address(0xBf6527834dBB89cdC97A79FCD62E6c08B19F8ec0);
+    address  public unirouter = address(0x039B5818e51dfEC86c1D56A4668787AF0Ed1c068); // Unisave
     address constant public weth = address(0xbb4CdB9CBd36B01bD1cBaEBF2De08d9173bc095c); // used for for <> weth <> usdc route
 
     address constant public yfii = address(0x7F70642d88cf1C4a3a7abb072B53B929b653edA5);


### PR DESCRIPTION
- USDT策略為舊版 Burger V1 Router, 已經棄用。換成 Unisave. 
- BNB策略為 Burger V2 Router。換成 Unisave. 
- BUSD策略為 Burger V2 Router。換成 Unisave. 
- ETH策略為 Burger V2 Router。換成 Unisave. 